### PR TITLE
dependencies: upgrade to react-native-svg v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/73R3WY/react-native-svg-animations",
   "dependencies": {
-    "react-native-svg": "^5.5.1",
+    "react-native-svg": "^9.3.6",
     "svg-path-properties": "^0.4.1"
   }
 }


### PR DESCRIPTION
The old version of react-native-svg (5.x.x) is breaking with react-native 0.59 (at least in android).
This update fixes the error and there seems to be no breaking changes